### PR TITLE
Fix of truncation error

### DIFF
--- a/code_FinalVersion/code_FinalVersion/scripts/samplecount.R
+++ b/code_FinalVersion/code_FinalVersion/scripts/samplecount.R
@@ -1,6 +1,7 @@
 sampleCount <- function(meancount, sdcount){
   
-  rtnorm(1, meancount, sdcount,0,2)
+  # single draw from the truncated normal dist. Lower bounded 0, no upper bound
+  rtnorm(n = 1, mean = meancount, sd = sdcount, lower = 0)
   
 }
 


### PR DESCRIPTION
the rtnorm function has an upper bound of 2. Even the Band spreadsheet example has some bird counts over 2, so creating downwards biased estimates if count data exceeds this